### PR TITLE
feat(default-model): changed creation of world/population with RNG

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,5 +2,7 @@
 <project version="4">
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/sats.iml
+++ b/sats.iml
@@ -12,7 +12,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: edu.harvard.eecs:jopt:1.3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.jgrapht:jgrapht-core:0.9.2" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: net.sf.jopt-simple:jopt-simple:5.0.2" level="project" />

--- a/src/main/java/org/spectrumauctions/sats/core/api/ModelCreator.java
+++ b/src/main/java/org/spectrumauctions/sats/core/api/ModelCreator.java
@@ -10,10 +10,7 @@ import org.spectrumauctions.sats.core.bidfile.FileWriter;
 import org.spectrumauctions.sats.core.bidlang.generic.GenericDefinition;
 import org.spectrumauctions.sats.core.bidlang.generic.GenericLang;
 import org.spectrumauctions.sats.core.bidlang.xor.XORLanguage;
-import org.spectrumauctions.sats.core.model.Bidder;
-import org.spectrumauctions.sats.core.model.DefaultModel;
-import org.spectrumauctions.sats.core.model.Good;
-import org.spectrumauctions.sats.core.model.UnsupportedBiddingLanguageException;
+import org.spectrumauctions.sats.core.model.*;
 import org.spectrumauctions.sats.core.util.file.FilePathUtils;
 
 import java.io.File;
@@ -84,15 +81,15 @@ public abstract class ModelCreator {
 
     public abstract PathResult generateResult(File outputFolder) throws UnsupportedBiddingLanguageException, IOException, IllegalConfigException;
 
-    protected PathResult appendTopLevelParamsAndSolve(DefaultModel<?, ?> model, File outputFolder) throws UnsupportedBiddingLanguageException, IOException, IllegalConfigException {
+    protected PathResult appendTopLevelParamsAndSolve(DefaultModel<? extends World, ? extends Bidder<? extends Good>> model, File outputFolder) throws UnsupportedBiddingLanguageException, IOException, IllegalConfigException {
 
         Collection<? extends Bidder<? extends Good>> bidders;
         if (seedType == SeedType.INDIVIDUALSEED) {
-            bidders = model.createNewPopulation(worldSeed, populationSeed);
+            bidders = model.createPopulation(worldSeed, populationSeed);
         } else if (seedType == SeedType.NOSEED) {
-            bidders = model.createNewPopulation();
+            bidders = model.createPopulation();
         } else if (seedType == SeedType.SUPERSEED) {
-            bidders = model.createNewPopulation(superSeed);
+            bidders = model.createPopulation(superSeed, superSeed);
         } else {
             throw new IllegalConfigException("Seed type unknown");
         }

--- a/src/main/java/org/spectrumauctions/sats/core/model/DefaultModel.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/DefaultModel.java
@@ -7,7 +7,6 @@ package org.spectrumauctions.sats.core.model;
 
 import org.spectrumauctions.sats.core.util.random.JavaUtilRNGSupplier;
 import org.spectrumauctions.sats.core.util.random.RNGSupplier;
-import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
 
 import java.util.List;
 
@@ -19,10 +18,11 @@ public abstract class DefaultModel<W extends World, B extends Bidder<? extends G
 
     /**
      * Creates a new {@link World}
-     * @param worldSeed A rng supplier for random creation of world parameters
      * @return a new world
      */
-    public abstract W createWorld(RNGSupplier worldSeed);
+    public W createWorld() {
+        return createWorld(new JavaUtilRNGSupplier());
+    }
 
     /**
      * Creates a new {@link World}
@@ -35,69 +35,26 @@ public abstract class DefaultModel<W extends World, B extends Bidder<? extends G
 
     /**
      * Creates a new {@link World}
+     * @param worldSeed A rng supplier for random creation of world parameters
      * @return a new world
      */
-    public W createWorld() {
-        return createWorld(new JavaUtilRNGSupplier());
-    }
-
+    public abstract W createWorld(RNGSupplier worldSeed);
 
     /**
-     * Creates a new set of {@link Bidder} instances
-     * @param world the {@link World} for which the bidders are created
-     * @param populationRNG a rng supplier for the creation of random bidder parameters
+     * Creates a new set of {@link Bidder} instances randomly
      * @return a new set of bidders
      */
-    public abstract List<B> createPopulation(W world, RNGSupplier populationRNG);
-
-    /**
-     * Creates a new set of {@link Bidder} instances
-     * @return a new set of bidders
-     */
-    public List<B> createNewPopulation() {
-        return createNewPopulation(new JavaUtilRNGSupplier());
+    public List<B> createPopulation() {
+        return createPopulation(createWorld());
     }
 
     /**
      * Creates a new set of {@link Bidder} instances
-     * @param seed the seed for the RNG
+     * @param world The world for which the bidders are created
      * @return a new set of bidders
      */
-    public List<B> createNewPopulation(long seed) {
-        return createNewPopulation(new JavaUtilRNGSupplier(seed));
-    }
-
-    /**
-     * Creates a new set of {@link Bidder} instances for a newly generated {@link World} instance
-     * @param rngSupplier A rng supplier for random creation of both world parameters and bidder paramters
-     * @return a new set of bidders
-     */
-    public List<B> createNewPopulation(RNGSupplier rngSupplier) {
-        UniformDistributionRNG rng = rngSupplier.getUniformDistributionRNG();
-        JavaUtilRNGSupplier worldSupplier = new JavaUtilRNGSupplier(rng.nextLong());
-        JavaUtilRNGSupplier populationSupplier = new JavaUtilRNGSupplier(rng.nextLong());
-        return createNewPopulation(worldSupplier, populationSupplier);
-    }
-
-    /**
-     * Creates a new set of {@link Bidder} instances for a newly generated {@link World} instance
-     * @param worldSeed A seed for random creation of world parameters
-     * @param populationSeed A seed for randmon creation of bidder parameters
-     * @return a new set of bidders
-     */
-    public List<B> createNewPopulation(long worldSeed, long populationSeed) {
-        return createNewPopulation(new JavaUtilRNGSupplier(worldSeed), new JavaUtilRNGSupplier(populationSeed));
-    }
-
-    /**
-     * Creates a new set of {@link Bidder} instances for a newly generated {@link World} instance
-     * @param worldRNG A rng supplier for random creation of world parameters
-     * @param populationRNG A rng supplier for randmon creation of bidder parameters
-     * @return a new set of bidders
-     */
-    public List<B> createNewPopulation(RNGSupplier worldRNG, RNGSupplier populationRNG) {
-        W world = createWorld(worldRNG);
-        return createPopulation(world, populationRNG);
+    public List<B> createPopulation(W world) {
+        return createPopulation(world, new JavaUtilRNGSupplier());
     }
 
     /**
@@ -112,12 +69,29 @@ public abstract class DefaultModel<W extends World, B extends Bidder<? extends G
 
     /**
      * Creates a new set of {@link Bidder} instances
-     * @param world The world for which the bidders are created
+     * @param worldSeed The seed for random creation of the world for which the bidders are created
+     * @param populationSeed A seed for random creation of bidder parameters
      * @return a new set of bidders
      */
-    public List<B> createPopulation(W world) {
-        return createPopulation(world, new JavaUtilRNGSupplier());
+    public List<B> createPopulation(long worldSeed, long populationSeed) {
+        return createPopulation(createWorld(worldSeed), populationSeed);
     }
 
+    /**
+     * Creates a new set of {@link Bidder} instances
+     * @param superSeed The seed for random creation of the world and the bidders
+     * @return a new set of bidders
+     */
+    public List<B> createPopulation(long superSeed) {
+        return createPopulation(createWorld(superSeed), superSeed);
+    }
+
+    /**
+     * Creates a new set of {@link Bidder} instances
+     * @param world the {@link World} for which the bidders are created
+     * @param populationRNG a rng supplier for the creation of random bidder parameters
+     * @return a new set of bidders
+     */
+    public abstract List<B> createPopulation(W world, RNGSupplier populationRNG);
 
 }

--- a/src/main/java/org/spectrumauctions/sats/core/model/bvm/bvm/BaseValueModel.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/bvm/bvm/BaseValueModel.java
@@ -7,6 +7,7 @@ package org.spectrumauctions.sats.core.model.bvm.bvm;
 
 import com.google.common.base.Preconditions;
 import org.spectrumauctions.sats.core.model.DefaultModel;
+import org.spectrumauctions.sats.core.model.World;
 import org.spectrumauctions.sats.core.model.bvm.BMBidder;
 import org.spectrumauctions.sats.core.model.bvm.BMBidderSetup;
 import org.spectrumauctions.sats.core.model.bvm.BMWorld;

--- a/src/test/java/org/spectrumauctions/sats/core/bidfile/BidFileWriter.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidfile/BidFileWriter.java
@@ -37,7 +37,7 @@ public abstract class BidFileWriter {
 
     protected void testMultiBidderXOR(FileWriter exporter) {
         BaseValueModel bvm = new BaseValueModel();
-        Collection<BMBidder> bidders = bvm.createNewPopulation(0L);
+        Collection<BMBidder> bidders = bvm.createPopulation(0L);
         Collection<XORLanguage<? extends Good>> languages = new ArrayList<>();
         int bidsPerBidder = 150;
         for (BMBidder bidder : bidders) {
@@ -63,7 +63,7 @@ public abstract class BidFileWriter {
 
     protected void testSingleBidderXOR(FileWriter exporter) {
         BaseValueModel bvm = new BaseValueModel();
-        Collection<BMBidder> bidders = bvm.createNewPopulation(0L);
+        Collection<BMBidder> bidders = bvm.createPopulation(0L);
         int bidsPerBidder = 150;
         for (BMBidder bidder : bidders) {
             try {
@@ -85,7 +85,7 @@ public abstract class BidFileWriter {
 
     protected void testMultiBidderXORQ(FileWriter exporter) {
         BaseValueModel bvm = new BaseValueModel();
-        Collection<BMBidder> bidders = bvm.createNewPopulation(0L);
+        Collection<BMBidder> bidders = bvm.createPopulation(0L);
         Collection<GenericLang<GenericDefinition<? extends Good>, ?>> languages = new ArrayList<>();
         int bidsPerBidder = 150;
         for (BMBidder bidder : bidders) {
@@ -109,7 +109,7 @@ public abstract class BidFileWriter {
 
     protected void testSingleBidderXORQ(FileWriter exporter) {
         BaseValueModel bvm = new BaseValueModel();
-        Collection<BMBidder> bidders = bvm.createNewPopulation(0L);
+        Collection<BMBidder> bidders = bvm.createPopulation(0L);
         int bidsPerBidder = 150;
         for (BMBidder bidder : bidders) {
             try {

--- a/src/test/java/org/spectrumauctions/sats/core/bidfile/CatsWriterTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidfile/CatsWriterTest.java
@@ -45,7 +45,7 @@ public class CatsWriterTest extends BidFileWriter {
         CatsExporter exporter = new CatsExporter(new File(EXPORT_TEST_FOLDER_NAME));
         CATSRegionModel model = new CATSRegionModel();
         model.setNumberOfBidders(25);
-        Collection<CATSBidder> bidders = model.createNewPopulation(21321468L);
+        Collection<CATSBidder> bidders = model.createPopulation(21321468L);
         Collection<XORLanguage<? extends Good>> langs = bidders.stream().map(b -> {
             try {
                 return b.getValueFunction(CatsXOR.class, 0L);

--- a/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/SimpleRandomOrder/SimpleRandomOrderTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/SimpleRandomOrder/SimpleRandomOrderTest.java
@@ -27,10 +27,10 @@ public class SimpleRandomOrderTest {
     @BeforeClass
     public static void setUpBeforeClass() {
         bidders = new HashMap<>();
-        bidders.put(new BaseValueModel().createNewPopulation().stream().findAny().orElse(null), (int) (0.8 * 140));
-        bidders.put(new MultiBandValueModel().createNewPopulation().stream().findAny().orElse(null), 500);
-        bidders.put(new SingleRegionModel().createNewPopulation().stream().findAny().orElse(null), 500);
-        bidders.put(new MultiRegionModel().createNewPopulation().stream().findAny().orElse(null), 500);
+        bidders.put(new BaseValueModel().createPopulation().stream().findAny().orElse(null), (int) (0.8 * 140));
+        bidders.put(new MultiBandValueModel().createPopulation().stream().findAny().orElse(null), 500);
+        bidders.put(new SingleRegionModel().createPopulation().stream().findAny().orElse(null), 500);
+        bidders.put(new MultiRegionModel().createPopulation().stream().findAny().orElse(null), 500);
     }
 
     @Test
@@ -42,7 +42,7 @@ public class SimpleRandomOrderTest {
 
     @Test
     public void testSRMSimpleRandomReduceBidAmount() {
-        Bidder bidder = new SingleRegionModel().createNewPopulation().stream().findAny().orElse(null);
+        Bidder bidder = new SingleRegionModel().createPopulation().stream().findAny().orElse(null);
         XORQRandomOrderSimple<?, ?> valueFunction;
         try {
             valueFunction = (XORQRandomOrderSimple) bidder.getValueFunction(XORQRandomOrderSimple.class);
@@ -59,7 +59,7 @@ public class SimpleRandomOrderTest {
 
     @Test
     public void testMRMSimpleRandomLarge() {
-        Bidder bidder = new MultiRegionModel().createNewPopulation().stream().findAny().orElse(null);
+        Bidder bidder = new MultiRegionModel().createPopulation().stream().findAny().orElse(null);
         XORQRandomOrderSimple<?, ?> valueFunction;
         try {
             valueFunction = (XORQRandomOrderSimple) bidder.getValueFunction(XORQRandomOrderSimple.class);

--- a/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/SizeOrderedPowerset/GenericPowersetTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/SizeOrderedPowerset/GenericPowersetTest.java
@@ -22,7 +22,7 @@ public class GenericPowersetTest {
     @Test
     public void testLargeAuctionMustNotStart() throws UnsupportedBiddingLanguageException {
         MultiRegionModel model = new MultiRegionModel();
-        MRVMBidder bidder = model.createNewPopulation(89127349).iterator().next();
+        MRVMBidder bidder = model.createPopulation(89127349).iterator().next();
         try {
             GenericLang<?, ?> lang = bidder.getValueFunction(GenericPowersetDecreasing.class);
             Assert.fail();

--- a/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/XORQtoXORTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidlang/generic/XORQtoXORTest.java
@@ -27,7 +27,7 @@ public class XORQtoXORTest {
     @Test
     public void testAllCombinations() throws UnsupportedBiddingLanguageException {
         MultiBandValueModel model = new MultiBandValueModel();
-        BMBidder bidder = model.createNewPopulation(51465435L).iterator().next();
+        BMBidder bidder = model.createPopulation(51465435L).iterator().next();
         @SuppressWarnings("unchecked")
         GenericPowersetDecreasing<BMBand, BMLicense> lang =
                 bidder.getValueFunction(GenericPowersetDecreasing.class, 351354);

--- a/src/test/java/org/spectrumauctions/sats/core/bidlang/xor/CatsXORTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/bidlang/xor/CatsXORTest.java
@@ -20,7 +20,7 @@ public class CatsXORTest {
         long seed = 156567345634L;
 
         CATSRegionModel model = new CATSRegionModel();
-        List<CATSBidder> bidders = model.createNewPopulation(seed - 1);
+        List<CATSBidder> bidders = model.createPopulation(seed - 1);
 
         List<XORValue<CATSLicense>> directBids = Lists.newArrayList();
         List<XORValue<CATSLicense>> iteratorBids = Lists.newArrayList();
@@ -64,7 +64,7 @@ public class CatsXORTest {
 
         CATSRegionModel model = new CATSRegionModel();
         model.setNumberOfGoods(4);
-        CATSBidder bidder = model.createNewPopulation(seed).stream().findAny().orElseThrow(IllegalArgumentException::new);
+        CATSBidder bidder = model.createPopulation(seed).stream().findAny().orElseThrow(IllegalArgumentException::new);
 
         CatsXOR valueFunction = bidder.getValueFunction(CatsXOR.class, seed + 1).noCapForSubstitutableGoods();
         Iterator<XORValue<CATSLicense>> catsIterator = valueFunction.iterator();
@@ -83,7 +83,7 @@ public class CatsXORTest {
     private void testNoCap(long seed) throws UnsupportedBiddingLanguageException {
 
         CATSRegionModel model = new CATSRegionModel();
-        CATSBidder bidder = model.createNewPopulation(seed).stream().findAny().orElseThrow(IllegalArgumentException::new);
+        CATSBidder bidder = model.createPopulation(seed).stream().findAny().orElseThrow(IllegalArgumentException::new);
 
         CatsXOR valueFunction = bidder.getValueFunction(CatsXOR.class, seed + 1).noCapForSubstitutableGoods();
         Iterator<XORValue<CATSLicense>> catsIterator = valueFunction.iterator();
@@ -145,7 +145,7 @@ public class CatsXORTest {
                 CATSRegionModel model = new CATSRegionModel();
                 model.setNumberOfGoods(256);
                 model.setNumberOfBidders(25);
-                List<CATSBidder> bidders = model.createNewPopulation(seed++);
+                List<CATSBidder> bidders = model.createPopulation(seed++);
                 numberOfBiddersSats += bidders.size();
 
                 for (CATSBidder bidder : bidders) {

--- a/src/test/java/org/spectrumauctions/sats/core/examples/BiddingLanguagesExample.java
+++ b/src/test/java/org/spectrumauctions/sats/core/examples/BiddingLanguagesExample.java
@@ -26,7 +26,7 @@ public class BiddingLanguagesExample {
      * See {@link SimpleModelAccessorsExample} and {@link ParameterizingModelsExample} for examples how bidders can be generated
      */
     private static SRVMBidder createAnyBidder() {
-        return new SingleRegionModel().createNewPopulation().stream().findAny().orElse(null);
+        return new SingleRegionModel().createPopulation().stream().findAny().orElse(null);
     }
 
     /**

--- a/src/test/java/org/spectrumauctions/sats/core/model/bvm/BMRandomnessTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/bvm/BMRandomnessTest.java
@@ -35,8 +35,8 @@ public class BMRandomnessTest {
         Assert.assertEquals(bidders1, bidders2);
         Assert.assertEquals(bidders2, bidders3);
         Assert.assertEquals(bidders3, bidders4);
-        bidders1 = model.createNewPopulation(seed);
-        bidders2 = model.createNewPopulation(seed);
+        bidders1 = model.createPopulation(seed);
+        bidders2 = model.createPopulation(seed);
         Assert.assertEquals(bidders1, bidders2);
     }
 
@@ -54,8 +54,8 @@ public class BMRandomnessTest {
         Assert.assertEquals(bidders1, bidders2);
         Assert.assertEquals(bidders2, bidders3);
         Assert.assertEquals(bidders3, bidders4);
-        bidders1 = model.createNewPopulation(seed);
-        bidders2 = model.createNewPopulation(seed);
+        bidders1 = model.createPopulation(seed);
+        bidders2 = model.createPopulation(seed);
         Assert.assertEquals(bidders1, bidders2);
     }
 }

--- a/src/test/java/org/spectrumauctions/sats/core/model/bvm/SizeOrderedIteratorTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/bvm/SizeOrderedIteratorTest.java
@@ -25,7 +25,7 @@ public class SizeOrderedIteratorTest {
     @Test
     public void testDecreasingIterator() throws UnsupportedBiddingLanguageException {
         BaseValueModel model = new BaseValueModel();
-        BMBidder bidder = model.createNewPopulation(51465435L).iterator().next();
+        BMBidder bidder = model.createPopulation(51465435L).iterator().next();
         @SuppressWarnings("unchecked")
         GenericSizeOrdered<BMBand, BMLicense> lang = bidder.getValueFunction(GenericSizeDecreasing.class, 351354);
         int currentSize = Integer.MAX_VALUE;
@@ -46,7 +46,7 @@ public class SizeOrderedIteratorTest {
     @Test
     public void testIncreasingIterator() throws UnsupportedBiddingLanguageException {
         BaseValueModel model = new BaseValueModel();
-        BMBidder bidder = model.createNewPopulation(51465435L).iterator().next();
+        BMBidder bidder = model.createPopulation(51465435L).iterator().next();
         @SuppressWarnings("unchecked")
         GenericSizeOrdered<BMBand, BMLicense> lang = bidder.getValueFunction(GenericSizeIncreasing.class, 351354);
         int currentSize = 0;

--- a/src/test/java/org/spectrumauctions/sats/core/model/bvm/SizeOrderedPowersetTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/bvm/SizeOrderedPowersetTest.java
@@ -25,7 +25,7 @@ public class SizeOrderedPowersetTest {
     @Test
     public void testDecreasingIterator() throws UnsupportedBiddingLanguageException {
         MultiBandValueModel model = new MultiBandValueModel();
-        BMBidder bidder = model.createNewPopulation(51465435L).iterator().next();
+        BMBidder bidder = model.createPopulation(51465435L).iterator().next();
         @SuppressWarnings("unchecked")
         GenericPowersetDecreasing<BMBand, BMLicense> lang = bidder.getValueFunction(GenericPowersetDecreasing.class, 351354);
         int currentSize = Integer.MAX_VALUE;
@@ -48,7 +48,7 @@ public class SizeOrderedPowersetTest {
     @Test
     public void testIncreasingIterator() throws UnsupportedBiddingLanguageException {
         BaseValueModel model = new BaseValueModel();
-        BMBidder bidder = model.createNewPopulation(51465435L).iterator().next();
+        BMBidder bidder = model.createPopulation(51465435L).iterator().next();
         @SuppressWarnings("unchecked")
         GenericPowersetIncreasing<BMBand, BMLicense> lang = bidder.getValueFunction(GenericPowersetIncreasing.class, 351354);
         int currentSize = 0;

--- a/src/test/java/org/spectrumauctions/sats/core/model/mrvm/MRVMRandomnessTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/mrvm/MRVMRandomnessTest.java
@@ -33,8 +33,8 @@ public class MRVMRandomnessTest {
         Assert.assertEquals(bidders1, bidders2);
         Assert.assertEquals(bidders2, bidders3);
         Assert.assertEquals(bidders3, bidders4);
-        bidders1 = model.createNewPopulation(seed);
-        bidders2 = model.createNewPopulation(seed);
+        bidders1 = model.createPopulation(seed);
+        bidders2 = model.createPopulation(seed);
         Assert.assertEquals(bidders1, bidders2);
     }
 }

--- a/src/test/java/org/spectrumauctions/sats/core/model/srvm/SRVMRandomnessTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/srvm/SRVMRandomnessTest.java
@@ -33,8 +33,8 @@ public class SRVMRandomnessTest {
         Assert.assertEquals(bidders1, bidders2);
         Assert.assertEquals(bidders2, bidders3);
         Assert.assertEquals(bidders3, bidders4);
-        bidders1 = model.createNewPopulation(seed);
-        bidders2 = model.createNewPopulation(seed);
+        bidders1 = model.createPopulation(seed);
+        bidders2 = model.createPopulation(seed);
         Assert.assertEquals(bidders1, bidders2);
     }
 }

--- a/src/test/java/org/spectrumauctions/sats/core/model/srvm/SRVMTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/srvm/SRVMTest.java
@@ -24,7 +24,7 @@ public class SRVMTest {
     @Test
     public void testNoRunimeException() throws UnsupportedBiddingLanguageException {
         SingleRegionModel model = new SingleRegionModel();
-        SRVMBidder bidder = model.createNewPopulation(238472).iterator().next();
+        SRVMBidder bidder = model.createPopulation(238472).iterator().next();
         GenericLang<SRVMBand, SRVMLicense> lang = bidder.getValueFunction(GenericSizeDecreasing.class);
         Iterator<GenericValue<SRVMBand, SRVMLicense>> iter = lang.iterator();
         for (int i = 0; i < 50 && iter.hasNext(); i++) {

--- a/src/test/java/org/spectrumauctions/sats/mechanism/cca/GSVMCCATest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/cca/GSVMCCATest.java
@@ -46,7 +46,7 @@ public class GSVMCCATest {
     }
 
     private void testClockPhaseVsSupplementaryPhaseEfficiency() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation();
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation();
         GSVMStandardMIP mip = new GSVMStandardMIP(Lists.newArrayList(rawBidders));
         mip.getMip().setSolveParam(SolveParam.RELATIVE_OBJ_GAP, 1e-5);
         ItemAllocation<GSVMLicense> efficientAllocation = mip.calculateAllocation();
@@ -109,7 +109,7 @@ public class GSVMCCATest {
 
     @Test
     public void testClonedCCA() {
-        NonGenericCCAMechanism<GSVMLicense> cca = getMechanism(new GlobalSynergyValueModel().createNewPopulation());
+        NonGenericCCAMechanism<GSVMLicense> cca = getMechanism(new GlobalSynergyValueModel().createPopulation());
         cca.setTimeLimit(10);
         assertNotNull(cca.getBidsAfterSupplementaryRound()); // Create bids
         NonGenericCCAMechanism<GSVMLicense> cloned = (NonGenericCCAMechanism<GSVMLicense>) cca.cloneWithoutSupplementaryBids();
@@ -120,7 +120,7 @@ public class GSVMCCATest {
 
     @Test
     public void testNoDuplicatesInSupplementaryRound() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation();
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<GSVMLicense> cca = getMechanism(rawBidders);
         cca.calculateSampledStartingPrices(50, 100 ,0.1);
         cca.setTimeLimit(30);
@@ -149,7 +149,7 @@ public class GSVMCCATest {
 
     @Test
     public void testMultipleSupplementaryRounds() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation();
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<GSVMLicense> cca = getMechanism(rawBidders);
 
         ProfitMaximizingNonGenericSupplementaryRound<GSVMLicense> supplementaryRoundLastPrices = new ProfitMaximizingNonGenericSupplementaryRound<>();
@@ -163,7 +163,7 @@ public class GSVMCCATest {
 
     @Test
     public void testSampledStartingPrices() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation();
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<GSVMLicense> ccaZero = getMechanism(rawBidders);
         long startZero = System.currentTimeMillis();
         Allocation<GSVMLicense> allocZero = ccaZero.calculateClockPhaseAllocation();
@@ -183,7 +183,7 @@ public class GSVMCCATest {
 
     @Test
     public void testDeterministicSampledStartingPrices() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation(123123);
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation(123123);
 
         NonGenericCCAMechanism<GSVMLicense> ccaSampled = getMechanism(rawBidders);
         ccaSampled.calculateSampledStartingPrices(10, 100, 0.1, 987987);
@@ -199,7 +199,7 @@ public class GSVMCCATest {
 
     @Test
     public void testLastBidsSupplementaryRound() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation();
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation();
         List<Bidder<GSVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<GSVMLicense>) b).collect(Collectors.toList());
         NonGenericCCAMechanism<GSVMLicense> cca = new NonGenericCCAMechanism<>(bidders, new GSVM_DemandQueryMIPBuilder());
@@ -232,7 +232,7 @@ public class GSVMCCATest {
 
     @Test
     public void testEfficiencyClockPhaseVsSupplementaryRound() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation(123456);
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation(123456);
         List<Bidder<GSVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<GSVMLicense>) b).collect(Collectors.toList());
         NonGenericCCAMechanism<GSVMLicense> cca = new NonGenericCCAMechanism<>(bidders, new GSVM_DemandQueryMIPBuilder());
@@ -282,7 +282,7 @@ public class GSVMCCATest {
 
     @Test
     public void testMinimalExample() {
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation(123456);
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation(123456);
         // The following line used to make a difference in the solution pool and thus the allocation, but it does not anymore
         // new FindJoptTest().joptLibrarySimpleExample();
         List<Bidder<GSVMLicense>> bidders = rawBidders.stream()
@@ -340,9 +340,9 @@ public class GSVMCCATest {
         pricesPerId.put(16L, BigDecimal.valueOf(-1 + 22.62962778408797590294467801744846023292005));
         pricesPerId.put(17L, BigDecimal.valueOf(-1 + 22.62962778408797590294467801744846023292005));
 
-        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createNewPopulation(123456);
+        List<GSVMBidder> rawBidders = new GlobalSynergyValueModel().createPopulation(123456);
         // The following line used to make a difference in the solution pool, but it does not anymore
-        // new GlobalSynergyValueModel().createNewPopulation();
+        // new GlobalSynergyValueModel().createPopulation();
         List<Bidder<GSVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<GSVMLicense>) b).collect(Collectors.toList());
         Bidder<GSVMLicense> firstBidder = bidders.get(0);

--- a/src/test/java/org/spectrumauctions/sats/mechanism/cca/LSVMCCATest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/cca/LSVMCCATest.java
@@ -46,7 +46,7 @@ public class LSVMCCATest {
     }
 
     private void testClockPhaseVsSupplementaryPhaseEfficiency() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation();
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation();
         LSVMStandardMIP mip = new LSVMStandardMIP(Lists.newArrayList(rawBidders));
         mip.getMip().setSolveParam(SolveParam.RELATIVE_OBJ_GAP, 1e-5);
         ItemAllocation<LSVMLicense> efficientAllocation = mip.calculateAllocation();
@@ -104,7 +104,7 @@ public class LSVMCCATest {
 
     @Test
     public void testNoDuplicatesInSupplementaryRound() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation();
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<LSVMLicense> cca = getMechanism(rawBidders);
         cca.calculateSampledStartingPrices(50, 100 ,0.1);
         cca.setTimeLimit(30);
@@ -133,7 +133,7 @@ public class LSVMCCATest {
 
     @Test
     public void testMultipleSupplementaryRounds() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation();
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<LSVMLicense> cca = getMechanism(rawBidders);
 
         ProfitMaximizingNonGenericSupplementaryRound<LSVMLicense> supplementaryRoundLastPrices = new ProfitMaximizingNonGenericSupplementaryRound<>();
@@ -147,7 +147,7 @@ public class LSVMCCATest {
 
     @Test
     public void testSampledStartingPrices() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation();
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation();
         NonGenericCCAMechanism<LSVMLicense> ccaZero = getMechanism(rawBidders);
         long startZero = System.currentTimeMillis();
         Allocation<LSVMLicense> allocZero = ccaZero.calculateClockPhaseAllocation();
@@ -166,7 +166,7 @@ public class LSVMCCATest {
     }
     @Test
     public void testLastBidsSupplementaryRound() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation();
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation();
         List<Bidder<LSVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<LSVMLicense>) b).collect(Collectors.toList());
         NonGenericCCAMechanism<LSVMLicense> cca = new NonGenericCCAMechanism<>(bidders, new LSVM_DemandQueryMIPBuilder());
@@ -199,15 +199,15 @@ public class LSVMCCATest {
 
     @Test
     public void testBidsAnomaly() {
-        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createNewPopulation(123456);
-        assertEquals(rawBidders, new LocalSynergyValueModel().createNewPopulation());
+        List<LSVMBidder> rawBidders = new LocalSynergyValueModel().createPopulation(123456);
+        assertEquals(rawBidders, new LocalSynergyValueModel().createPopulation());
         List<Collection<XORBid<LSVMLicense>>> resultingBids = new ArrayList<>();
         List<Bidder<LSVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<LSVMLicense>) b).collect(Collectors.toList());
         resultingBids.add(runStandardCCA(bidders));
         //for (int i = 0; i < 3; i++) {
         //    // Unrelated code
-        //    new LocalSynergyValueModel().createNewPopulation();
+        //    new LocalSynergyValueModel().createPopulation();
         //    // Add another instance
         //    resultingBids.add(runStandardCCA(bidders));
         //}

--- a/src/test/java/org/spectrumauctions/sats/mechanism/cca/MRVMCCATest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/cca/MRVMCCATest.java
@@ -43,7 +43,7 @@ public class MRVMCCATest {
     }
 
     private void testClockPhaseVsSupplementaryPhaseEfficiency() {
-        List<MRVMBidder> rawBidders = new MultiRegionModel().createNewPopulation();
+        List<MRVMBidder> rawBidders = new MultiRegionModel().createPopulation();
         MRVM_MIP mip = new MRVM_MIP(Sets.newHashSet(rawBidders));
         mip.setEpsilon(1e-5);
         MRVMMipResult efficientAllocation = mip.calculateAllocation();
@@ -128,7 +128,7 @@ public class MRVMCCATest {
 
     @Test
     public void testMultipleSupplementaryRounds() {
-        List<MRVMBidder> rawBidders = new MultiRegionModel().createNewPopulation();
+        List<MRVMBidder> rawBidders = new MultiRegionModel().createPopulation();
         GenericCCAMechanism<MRVMGenericDefinition, MRVMLicense> cca = getMechanism(rawBidders);
 
         ProfitMaximizingGenericSupplementaryRound<MRVMGenericDefinition, MRVMLicense> supplementaryRoundLastPrices = new ProfitMaximizingGenericSupplementaryRound<>();
@@ -142,7 +142,7 @@ public class MRVMCCATest {
 
     @Test
     public void testSampledStartingPrices() {
-        List<MRVMBidder> rawBidders = new MultiRegionModel().createNewPopulation();
+        List<MRVMBidder> rawBidders = new MultiRegionModel().createPopulation();
         GenericCCAMechanism<MRVMGenericDefinition, MRVMLicense> ccaZero = getMechanism(rawBidders);
         long startZero = System.currentTimeMillis();
         Allocation<MRVMLicense> allocZero = ccaZero.calculateClockPhaseAllocation();
@@ -162,8 +162,8 @@ public class MRVMCCATest {
 
     @Test
     public void testDeterministicSampledStartingPrices() {
-        List<MRVMBidder> rawBidders = new MultiRegionModel().createNewPopulation(123123);
-        List<MRVMBidder> rawBidders2 = new MultiRegionModel().createNewPopulation(123123);
+        List<MRVMBidder> rawBidders = new MultiRegionModel().createPopulation(123123);
+        List<MRVMBidder> rawBidders2 = new MultiRegionModel().createPopulation(123123);
         assertEquals(rawBidders, rawBidders2);
         assertEquals(rawBidders.iterator().next().getWorld(), rawBidders2.iterator().next().getWorld());
 
@@ -180,7 +180,7 @@ public class MRVMCCATest {
 
     @Test
     public void testLastBidsSupplementaryRound() {
-        List<MRVMBidder> rawBidders = new MultiRegionModel().createNewPopulation();
+        List<MRVMBidder> rawBidders = new MultiRegionModel().createPopulation();
         List<Bidder<MRVMLicense>> bidders = rawBidders.stream()
                 .map(b -> (Bidder<MRVMLicense>) b).collect(Collectors.toList());
         GenericCCAMechanism<MRVMGenericDefinition, MRVMLicense> cca = new GenericCCAMechanism<>(bidders, new MRVM_DemandQueryMIPBuilder());

--- a/src/test/java/org/spectrumauctions/sats/mechanism/ccg/CCGTest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/ccg/CCGTest.java
@@ -271,7 +271,7 @@ public class CCGTest {
     @Test
     @Ignore // Takes a long time
     public void testCCGWithStandardMRVM() {
-        List<MRVMBidder> bidders = new MultiRegionModel().createNewPopulation(234456867);
+        List<MRVMBidder> bidders = new MultiRegionModel().createPopulation(234456867);
         WinnerDeterminator<MRVMLicense> wdp = new MRVM_MIP(bidders);
         AuctionMechanism<MRVMLicense> am = new CCGMechanism<>(wdp);
         Payment<MRVMLicense> payment = am.getPayment();

--- a/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithGSVMTest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithGSVMTest.java
@@ -23,7 +23,7 @@ public class VCGWithGSVMTest {
 
     @Test
     public void testVCGWithStandardGSVM() {
-        List<GSVMBidder> bidders = new GlobalSynergyValueModel().createNewPopulation(234556782);
+        List<GSVMBidder> bidders = new GlobalSynergyValueModel().createPopulation(234556782);
         WinnerDeterminator<GSVMLicense> wdp = new GSVMStandardMIP(bidders);
         AuctionMechanism<GSVMLicense> am = new VCGMechanism<>(wdp);
         Payment<GSVMLicense> payment = am.getPayment();

--- a/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithLSVMTest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithLSVMTest.java
@@ -21,7 +21,7 @@ public class VCGWithLSVMTest {
 
     @Test
     public void testVCGWithStandardLSVM() {
-        List<LSVMBidder> bidders = new LocalSynergyValueModel().createNewPopulation(2345567);
+        List<LSVMBidder> bidders = new LocalSynergyValueModel().createPopulation(2345567);
         WinnerDeterminator<LSVMLicense> wdp = new LSVMStandardMIP(bidders);
         AuctionMechanism<LSVMLicense> am = new VCGMechanism<>(wdp);
         Payment<LSVMLicense> payment = am.getPayment();

--- a/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithMRVMTest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithMRVMTest.java
@@ -31,7 +31,7 @@ public class VCGWithMRVMTest {
     @Test
     @Ignore
     public void testVCGWithStandardMRVM() {
-        List<MRVMBidder> bidders = new MultiRegionModel().createNewPopulation(234456867);
+        List<MRVMBidder> bidders = new MultiRegionModel().createPopulation(234456867);
         WinnerDeterminator<MRVMLicense> wdp = new MRVM_MIP(bidders);
         AuctionMechanism<MRVMLicense> am = new VCGMechanism<>(wdp);
         Payment<MRVMLicense> payment = am.getPayment();

--- a/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithSRVMTest.java
+++ b/src/test/java/org/spectrumauctions/sats/mechanism/vcg/VCGWithSRVMTest.java
@@ -29,7 +29,7 @@ public class VCGWithSRVMTest {
 
     @Test
     public void testVCGWithStandardSRVM() {
-        List<SRVMBidder> bidders = new SingleRegionModel().createNewPopulation(234456867);
+        List<SRVMBidder> bidders = new SingleRegionModel().createPopulation(234456867);
         WinnerDeterminator<SRVMLicense> wdp = new SRVM_MIP(bidders);
         AuctionMechanism<SRVMLicense> am = new VCGMechanism<>(wdp);
         Payment<SRVMLicense> payment = am.getPayment();

--- a/src/test/java/org/spectrumauctions/sats/opt/examples/BasicExamples.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/examples/BasicExamples.java
@@ -37,7 +37,7 @@ public class BasicExamples {
     @Test
     @Ignore
     public void basicMRVMExample() {
-        Collection<MRVMBidder> bidders = (new MultiRegionModel()).createNewPopulation();    // Create bidders
+        Collection<MRVMBidder> bidders = (new MultiRegionModel()).createPopulation();    // Create bidders
         MRVM_MIP mip = new MRVM_MIP(bidders);                                               // Create the MIP
         MRVMMipResult result = mip.calculateAllocation();                                   // Solve the MIP
         logger.info(result);                                                                // Show the allocation
@@ -46,7 +46,7 @@ public class BasicExamples {
     @Test
     @Ignore
     public void basicSRVMExample() {
-        Collection<SRVMBidder> bidders = (new SingleRegionModel()).createNewPopulation();   // Create bidders
+        Collection<SRVMBidder> bidders = (new SingleRegionModel()).createPopulation();   // Create bidders
         SRVM_MIP mip = new SRVM_MIP(bidders);                                               // Create the MIP
         SRVMMipResult result = mip.calculateAllocation();                                   // Solve the MIP
         logger.info(result);                                                                // Show the allocation
@@ -55,7 +55,7 @@ public class BasicExamples {
     @Test
     @Ignore
     public void basicGSVMExample() {
-        List<GSVMBidder> bidders = (new GlobalSynergyValueModel()).createNewPopulation();   // Create bidders
+        List<GSVMBidder> bidders = (new GlobalSynergyValueModel()).createPopulation();   // Create bidders
         GSVMStandardMIP mip = new GSVMStandardMIP(bidders);                                 // Create the MIP
         ItemAllocation<GSVMLicense> result = mip.calculateAllocation();                     // Solve the MIP
         for (Bidder<GSVMLicense> bidder : result.getWinners()) {

--- a/src/test/java/org/spectrumauctions/sats/opt/examples/CustomizedExamples.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/examples/CustomizedExamples.java
@@ -38,7 +38,7 @@ public class CustomizedExamples {
         model.setNumberOfNationalBidders(1);
         model.setNumberOfRegionalBidders(2);
 
-        Collection<MRVMBidder> bidders = model.createNewPopulation();   // Create bidders
+        Collection<MRVMBidder> bidders = model.createPopulation();   // Create bidders
         MRVM_MIP mip = new MRVM_MIP(bidders);                           // Create the MIP
         MRVMMipResult result = mip.calculateAllocation();               // Solve the MIP
         logger.info("Result:\n" + result);                           // Show the allocation

--- a/src/test/java/org/spectrumauctions/sats/opt/imip/ModelMIPTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/imip/ModelMIPTest.java
@@ -25,7 +25,7 @@ public class ModelMIPTest {
 
     @Test
     public void setAcceptSuboptimalSolutionAtTimeout() {
-        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createNewPopulation(5413646L));
+        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createPopulation(5413646L));
         Assert.assertTrue(mip.getMip().getDoubleSolveParam(SolveParam.TIME_LIMIT) > 2);
         mip.setTimeLimit(2);
         Assert.assertEquals(2, mip.getMip().getDoubleSolveParam(SolveParam.TIME_LIMIT), 1e-6);
@@ -35,7 +35,7 @@ public class ModelMIPTest {
 
     @Test
     public void setAcceptNoSuboptimalSolutionAtTimeout() {
-        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createNewPopulation(5413646L));
+        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createPopulation(5413646L));
         Assert.assertTrue(mip.getMip().getDoubleSolveParam(SolveParam.TIME_LIMIT) > 2);
         mip.setTimeLimit(2);
         Assert.assertEquals(2, mip.getMip().getDoubleSolveParam(SolveParam.TIME_LIMIT), 1e-6);
@@ -57,7 +57,7 @@ public class ModelMIPTest {
 
     @Test
     public void setDisplayOutput() {
-        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createNewPopulation(5413646L));
+        MRVM_MIP mip = new MRVM_MIP(new MultiRegionModel().createPopulation(5413646L));
         Assert.assertFalse(mip.getMip().getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT));
         mip.setDisplayOutput(true);
         Assert.assertTrue(mip.getMip().getBooleanSolveParam(SolveParam.DISPLAY_OUTPUT));

--- a/src/test/java/org/spectrumauctions/sats/opt/model/gsvm/demandquery/GSVMDemandQueryTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/gsvm/demandquery/GSVMDemandQueryTest.java
@@ -24,7 +24,7 @@ public class GSVMDemandQueryTest {
 
     @Test
     public void testAllBiddersInGSVM() {
-        List<GSVMBidder> bidders = new GlobalSynergyValueModel().createNewPopulation(new JavaUtilRNGSupplier(73246104));
+        List<GSVMBidder> bidders = new GlobalSynergyValueModel().createPopulation(73246104);
         GSVMWorld world = bidders.iterator().next().getWorld();
         Map<GSVMLicense, BigDecimal> prices = new HashMap<>();
         world.getLicenses().forEach(license -> prices.put(license, BigDecimal.valueOf(0)));

--- a/src/test/java/org/spectrumauctions/sats/opt/model/lsvm/demandquery/LSVMDemandQueryTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/lsvm/demandquery/LSVMDemandQueryTest.java
@@ -25,7 +25,7 @@ public class LSVMDemandQueryTest {
 
     @Test
     public void testAllBiddersInLSVM() {
-        List<LSVMBidder> bidders = new LocalSynergyValueModel().createNewPopulation(new JavaUtilRNGSupplier(73246104));
+        List<LSVMBidder> bidders = new LocalSynergyValueModel().createPopulation(73246104);
         LSVMWorld world = bidders.iterator().next().getWorld();
         Map<LSVMLicense, BigDecimal> prices = new HashMap<>();
         world.getLicenses().forEach(license -> prices.put(license, BigDecimal.TEN));

--- a/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/MRVMNationalBidderPartialMipBigScale.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/MRVMNationalBidderPartialMipBigScale.java
@@ -35,7 +35,7 @@ public class MRVMNationalBidderPartialMipBigScale {
         model.setNumberOfNationalBidders(3);
         model.setNumberOfLocalBidders(0);
         model.setNumberOfRegionalBidders(0);
-        Collection<MRVMBidder> bidders = model.createNewPopulation(5413646L);
+        Collection<MRVMBidder> bidders = model.createPopulation(5413646L);
         double scalingFactor = Scalor.scalingFactor(bidders);
         double biggestScaledValue = Scalor.biggestUnscaledPossibleValue(bidders).doubleValue() / scalingFactor;
         MRVMWorldPartialMip worldPartialMip = new MRVMWorldPartialMip(bidders, biggestScaledValue);
@@ -59,7 +59,7 @@ public class MRVMNationalBidderPartialMipBigScale {
         model.setNumberOfNationalBidders(3);
         model.setNumberOfLocalBidders(0);
         model.setNumberOfRegionalBidders(0);
-        Collection<MRVMBidder> bidders = model.createNewPopulation(5413646L);
+        Collection<MRVMBidder> bidders = model.createPopulation(5413646L);
         MRVMWorld world = bidders.iterator().next().getWorld();
         double scalingFactor = Scalor.scalingFactor(bidders);
         double biggestScaledValue = Scalor.biggestUnscaledPossibleValue(bidders).doubleValue() / scalingFactor;
@@ -124,7 +124,7 @@ public class MRVMNationalBidderPartialMipBigScale {
         model.setNumberOfNationalBidders(3);
         model.setNumberOfLocalBidders(0);
         model.setNumberOfRegionalBidders(0);
-        Collection<MRVMBidder> bidders = model.createNewPopulation(5413646L);
+        Collection<MRVMBidder> bidders = model.createPopulation(5413646L);
         double scalingFactor = Scalor.scalingFactor(bidders);
         double biggestScaledValue = Scalor.biggestUnscaledPossibleValue(bidders).doubleValue() / scalingFactor;
         MRVMWorldPartialMip worldPartialMip = new MRVMWorldPartialMip(bidders, biggestScaledValue);
@@ -186,7 +186,7 @@ public class MRVMNationalBidderPartialMipBigScale {
         model.setNumberOfNationalBidders(1);
         model.setNumberOfLocalBidders(0);
         model.setNumberOfRegionalBidders(0);
-        Collection<MRVMBidder> bidders = model.createNewPopulation(5413646L);
+        Collection<MRVMBidder> bidders = model.createPopulation(5413646L);
         MRVMWorld world = bidders.iterator().next().getWorld();
         double scalingFactor = Scalor.scalingFactor(bidders);
         double biggestScaledValue = Scalor.biggestUnscaledPossibleValue(bidders).doubleValue() / scalingFactor;

--- a/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/MRVMOverallValueTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/MRVMOverallValueTest.java
@@ -40,7 +40,7 @@ public class MRVMOverallValueTest {
     @Test
     @Ignore // Ignored for performance reasons
     public void mipValuesEqualSATSValues() {
-        List<MRVMBidder> bidders = new MultiRegionModel().createNewPopulation();
+        List<MRVMBidder> bidders = new MultiRegionModel().createPopulation();
         //Sort by bidder type
         bidders.sort(Comparator.comparing(b -> b.getClass().getSimpleName()));
         MRVM_MIP mip = new MRVM_MIP(bidders);

--- a/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/demandquery/MRVMDemandQueryTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/mrvm/demandquery/MRVMDemandQueryTest.java
@@ -46,7 +46,7 @@ public class MRVMDemandQueryTest {
 
     @Test
     public void testAllBiddersInStandardModel() {
-        List<MRVMBidder> bidders = new MultiRegionModel().createNewPopulation(new JavaUtilRNGSupplier(73246104));
+        List<MRVMBidder> bidders = new MultiRegionModel().createPopulation(73246104);
         MRVMWorld world = bidders.iterator().next().getWorld();
         Map<MRVMGenericDefinition, BigDecimal> prices = new HashMap<>();
         world.getAllGenericDefinitions().forEach(def -> prices.put((MRVMGenericDefinition) def, BigDecimal.valueOf(1000000)));
@@ -61,7 +61,7 @@ public class MRVMDemandQueryTest {
 
     @Test
     public void testSingleBidderResultPool() {
-        List<MRVMBidder> bidders = new MultiRegionModel().createNewPopulation(new JavaUtilRNGSupplier(73246104));
+        List<MRVMBidder> bidders = new MultiRegionModel().createPopulation(73246104);
         MRVMBidder bidder = bidders.get(bidders.size() - 1);
         MRVMWorld world = bidders.iterator().next().getWorld();
         Map<MRVMGenericDefinition, BigDecimal> prices = new HashMap<>();

--- a/src/test/java/org/spectrumauctions/sats/opt/model/srvm/SRVMMipTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/srvm/SRVMMipTest.java
@@ -25,7 +25,7 @@ public class SRVMMipTest {
 
     @Test
     public void testNoException() {
-        Collection<SRVMBidder> bidders = (new SingleRegionModel()).createNewPopulation();
+        Collection<SRVMBidder> bidders = (new SingleRegionModel()).createPopulation();
         SRVM_MIP mip = new SRVM_MIP(bidders);
         SRVMMipResult result = mip.calculateAllocation();
         for (SRVMBidder bidder : bidders) {

--- a/src/test/java/org/spectrumauctions/sats/opt/model/srvm/SRVMOverallValueTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/srvm/SRVMOverallValueTest.java
@@ -25,7 +25,7 @@ public class SRVMOverallValueTest {
     @Test
     @Ignore // TODO: There's still a slight difference between the values from sats-core and sats-opt
     public void mipValuesEqualSATSValues() {
-        List<SRVMBidder> bidders = new SingleRegionModel().createNewPopulation();
+        List<SRVMBidder> bidders = new SingleRegionModel().createPopulation();
         SRVM_MIP mip = new SRVM_MIP(bidders);
         SRVMMipResult result = mip.calculateAllocation();
         for (SRVMBidder bidder : bidders) {


### PR DESCRIPTION
As suggested by @blubin and Gianluca, this PR changes the creation of a world and its population regarding randomness/seeds.

Before, if a single seed was given to create a new populaiton, two new seeds were created based on the single seed, where the first was used to create the world and the second was used to create the population. This clashed with the way users would create the population in two steps (creating the world with seed X, then creating the population with seed X). Thus, this PR unifies these ways.