### PR TITLE
Fix mrvm mechlib issues

### DIFF
--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBand.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBand.java
@@ -33,7 +33,7 @@ public final class MRVMBand extends GenericGood {
 
     public static HashSet<MRVMBand> createBands(MRVMWorld world, MRVMWorldSetup worldSetup, MRVMRegionsMap regionsMap, UniformDistributionRNG rng) {
         Set<MRVMWorldSetup.BandSetup> bandSetups = worldSetup.getBandSetups();
-        HashSet<MRVMBand> bands = new HashSet<>();
+        HashSet<MRVMBand> bands = new LinkedHashSet<>();
         int currentLicenseId = 0;
         for (MRVMWorldSetup.BandSetup bandSetup : bandSetups) {
             MRVMBand band = new MRVMBand(bandSetup, world, currentLicenseId, rng);

--- a/src/main/java/org/spectrumauctions/sats/opt/model/mrvm/MRVM_MIP.java
+++ b/src/main/java/org/spectrumauctions/sats/opt/model/mrvm/MRVM_MIP.java
@@ -124,7 +124,7 @@ public class MRVM_MIP extends ModelMIP {
                     double doubleQuantity = solution.getValue(xVar);
                     int quantity = (int) Math.round(doubleQuantity);
                     if (quantity > 0) {
-                        MRVMGenericDefinition def = new MRVMGenericDefinition(band, region);
+                        MRVMGenericDefinition def = world.getAllGenericDefinitions().stream().filter(g -> g.getBand().equals(band) && g.getRegion().equals(region)).findFirst().get();
                         bundleEntries.add(new BundleEntry(def, quantity));
                     }
                 }


### PR DESCRIPTION
1. MRVM bands get ordered by creation
   -> independent of MRVMBand.hash
   -> independent implementation of java.util.HashMap
  
   enables deterministic execution with the same input parameters (and also comparision with "old" SATS)

2. MRVMGenericDefinition which are .equal do not have the same UUID. Quick fix -> do not create new MRVMGenericDefinition but rather reuse existing object