### PR TITLE
Adapt to new mechlib Bidder interface - set default demand query epsilon

### DIFF
--- a/src/main/java/org/spectrumauctions/sats/core/model/SATSBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/SATSBidder.java
@@ -33,6 +33,8 @@ public abstract class SATSBidder implements Bidder, Serializable {
     private final long id;
     private final long worldId;
     private transient final BidderSetup setup;
+    
+    protected static final double DEFAULT_DEMAND_QUERY_EPSILON = 1e-10;
 
     protected SATSBidder(BidderSetup setup, long population, long id, long worldId) {
         this.uuid = UUID.randomUUID();

--- a/src/main/java/org/spectrumauctions/sats/core/model/bvm/BMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/bvm/BMBidder.java
@@ -282,7 +282,7 @@ public final class BMBidder extends SATSBidder {
 
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         throw new NotImplementedException("Demand Query to be implemented");
     }
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/cats/CATSBidder.java
@@ -113,7 +113,7 @@ public final class CATSBidder extends SATSBidder {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         throw new NotImplementedException("Demand Query to be implemented");
     }
 }

--- a/src/main/java/org/spectrumauctions/sats/core/model/gsvm/GSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/gsvm/GSVMBidder.java
@@ -119,7 +119,7 @@ public final class GSVMBidder extends SATSBidder {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         GSVMStandardMIP mip = new GSVMStandardMIP(world, Lists.newArrayList(this), true);
         mip.setMipInstrumentation(getMipInstrumentation());
         mip.setPurpose(MipInstrumentation.MipPurpose.DEMAND_QUERY);
@@ -135,6 +135,9 @@ public final class GSVMBidder extends SATSBidder {
             }
         }
         mip.getMIP().add(price);
+        
+        mip.setEpsilon(DEFAULT_DEMAND_QUERY_EPSILON);
+        
         List<Allocation> optimalAllocations = mip.getBestAllocations(maxNumberOfBundles, allowNegative);
 
         List<Bundle> result = optimalAllocations.stream()

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -139,7 +139,7 @@ public final class LSVMBidder extends SATSBidder {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         LSVMStandardMIP mip = new LSVMStandardMIP(world, Lists.newArrayList(this));
         mip.setMipInstrumentation(getMipInstrumentation());
         mip.setPurpose(MipInstrumentation.MipPurpose.DEMAND_QUERY);
@@ -155,6 +155,9 @@ public final class LSVMBidder extends SATSBidder {
             }
         }
         mip.getMIP().add(price);
+        
+        mip.setEpsilon(DEFAULT_DEMAND_QUERY_EPSILON);
+        
         List<Allocation> optimalAllocations = mip.getBestAllocations(maxNumberOfBundles);
 
         List<Bundle> result = optimalAllocations.stream()

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
@@ -234,7 +234,7 @@ public abstract class MRVMBidder extends SATSBidder {
     }
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         MRVM_MIP mip = new MRVM_MIP(Sets.newHashSet(this));
         mip.setMipInstrumentation(getMipInstrumentation());
         mip.setPurpose(MipInstrumentation.MipPurpose.DEMAND_QUERY);
@@ -250,10 +250,8 @@ public abstract class MRVMBidder extends SATSBidder {
             price.addTerm(prices.getPrice(Bundle.of(bandInRegion)).getAmount().doubleValue() / scalingFactor, xVariable);
         }
         mip.addConstraint(price);
-
-        mip.setRelativePoolMode4Tolerance(relPoolTolerance);
-        mip.setAbsolutePoolMode4Tolerance(absPoolTolerance);
-        mip.setTimeLimitPoolMode4(poolTimeLimit);
+        
+        mip.setEpsilon(DEFAULT_DEMAND_QUERY_EPSILON);
 
         List<Allocation> optimalAllocations = mip.getBestAllocations(maxNumberOfBundles, allowNegative);
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/srvm/SRVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/srvm/SRVMBidder.java
@@ -235,7 +235,7 @@ public final class SRVMBidder extends SATSBidder {
 
 
     @Override
-    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative, double relPoolTolerance, double absPoolTolerance, double poolTimeLimit) {
+    public List<Bundle> getBestBundles(Prices prices, int maxNumberOfBundles, boolean allowNegative) {
         throw new NotImplementedException("Demand Query to be implemented");
     }
 


### PR DESCRIPTION
PR contains the following changes

- Update demand query method of all bidders
- Change default epsilon of GSVM/LSVM/MRVM to 1e-10 to be inline with the final version of Gianluca
