### PR TITLE
Demand Query shall return no bundles with items with zero marginal value

### DIFF
--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -36,7 +36,7 @@ public final class LSVMBidder extends SATSBidder {
     private final HashMap<Long, BigDecimal> values;
     private transient LSVMWorld world;
     private final String description;
-    private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
+    private final boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
     LSVMBidder(LSVMBidderSetup setup, LSVMWorld world, long currentId, long population, RNGSupplier rngSupplier) {
         super(setup, population, currentId, world.getId());
@@ -54,6 +54,7 @@ public final class LSVMBidder extends SATSBidder {
                 ", thus interested in licenses "
                 + this.proximity.stream().map(LSVMLicense::getName).collect(Collectors.joining(", "))
                 + ".";
+        this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = setup.isAllowAssigningLicensesWithZeroBasevalueInDemandQuery();
         store();
     }
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -36,6 +36,7 @@ public final class LSVMBidder extends SATSBidder {
     private final HashMap<Long, BigDecimal> values;
     private transient LSVMWorld world;
     private final String description;
+    private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
 
     LSVMBidder(LSVMBidderSetup setup, LSVMWorld world, long currentId, long population, RNGSupplier rngSupplier) {
         super(setup, population, currentId, world.getId());
@@ -149,15 +150,26 @@ public final class LSVMBidder extends SATSBidder {
         Constraint price = new Constraint(CompareType.EQ, 0);
         price.addTerm(-1, priceVar);
         for (LSVMLicense license : world.getLicenses()) {
-            Map<Integer, Variable> xVariables = mip.getXVariables(this, license);
-            for (Variable xVariable : xVariables.values()) {
-                price.addTerm(prices.getPrice(Bundle.of(license)).getAmount().doubleValue(), xVariable);
-            }
+        	Map<Integer, Variable> xVariables = mip.getXVariables(this, license);
+        	for (Variable xVariable : xVariables.values()) {
+        		if(this.proximity.contains(license) || this.allowAssigningLicensesWithZeroBasevalueInDemandQuery) {
+        			price.addTerm(prices.getPrice(Bundle.of(license)).getAmount().doubleValue(), xVariable);
+        		} else {
+        			xVariable.setUpperBound(0);
+        		}
+        	}
+
         }
         mip.getMIP().add(price);
         
         mip.setEpsilon(DEFAULT_DEMAND_QUERY_EPSILON);
         mip.setTimeLimit(DEFAULT_DEMAND_QUERY_TIME_LIMIT);
+        
+        if(this.allowAssigningLicensesWithZeroBasevalueInDemandQuery) {
+        	maxNumberOfBundles = Math.min(maxNumberOfBundles, (int) Math.pow(2, this.getWorld().getNumberOfGoods()));
+        } else {
+        	maxNumberOfBundles = Math.min(maxNumberOfBundles, (int) Math.pow(2, this.getProximity().size()));
+        }
         
         List<Allocation> optimalAllocations = mip.getBestAllocations(maxNumberOfBundles, allowNegative);
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidderSetup.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidderSetup.java
@@ -1,5 +1,7 @@
 package org.spectrumauctions.sats.core.model.lsvm;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.spectrumauctions.sats.core.model.BidderSetup;
 import org.spectrumauctions.sats.core.util.PreconditionUtils;
 import org.spectrumauctions.sats.core.util.random.DoubleInterval;
@@ -19,6 +21,8 @@ public class LSVMBidderSetup extends BidderSetup {
     private final int proximitySize;
     private final int a;
     private final int b;
+    @Getter
+    private final boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
     private LSVMBidderSetup(Builder builder) {
         super(builder);
@@ -26,6 +30,7 @@ public class LSVMBidderSetup extends BidderSetup {
         this.proximitySize = builder.proximitySize;
         this.a = builder.a;
         this.b = builder.b;
+        this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = builder.allowAssigningLicensesWithZeroBasevalueInDemandQuery;
     }
 
     LSVMLicense drawFavorite(RNGSupplier rngSupplier, LSVMWorld world) {
@@ -66,6 +71,8 @@ public class LSVMBidderSetup extends BidderSetup {
         private int proximitySize;
         private int a;
         private int b;
+        @Setter
+        private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
         private Builder(String setupName, int numberOfBidders, DoubleInterval valueInterval, int proximitySize, int a, int b) {
             super(setupName, numberOfBidders);
@@ -73,6 +80,7 @@ public class LSVMBidderSetup extends BidderSetup {
             this.proximitySize = proximitySize;
             this.a = a;
             this.b = b;
+            this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
         }
 
         public void setValueInterval(DoubleInterval newInterval) {

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
@@ -261,6 +261,12 @@ public abstract class MRVMBidder extends SATSBidder {
         return result;
     }
     
+    /**
+     * Allows a specific bidder type (subclass) to change the demand query mip before 
+     * execution. I.e. restrict demand query result to items where the bidder is interested in.
+     * 
+     * @param mip
+     */
     protected abstract void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip);
 
     /**

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
@@ -261,9 +261,7 @@ public abstract class MRVMBidder extends SATSBidder {
         return result;
     }
     
-    protected void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip) {
-    	// Do nothing here
-    }
+    protected abstract void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip);
 
     /**
      * @see SATSBidder#refreshReference(World)

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMBidder.java
@@ -254,6 +254,8 @@ public abstract class MRVMBidder extends SATSBidder {
         
         mip.setEpsilon(DEFAULT_DEMAND_QUERY_EPSILON);
         mip.setTimeLimit(DEFAULT_DEMAND_QUERY_TIME_LIMIT);
+        
+        this.bidderTypeSpecificDemandQueryMIPAdjustments(mip);
 
         List<Allocation> optimalAllocations = mip.getBestAllocations(maxNumberOfBundles, allowNegative);
 
@@ -262,6 +264,10 @@ public abstract class MRVMBidder extends SATSBidder {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         if (result.isEmpty()) result.add(Bundle.EMPTY);
         return result;
+    }
+    
+    protected void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip) {
+    	// Do nothing here
     }
 
     /**

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidder.java
@@ -112,7 +112,6 @@ public final class MRVMLocalBidder extends MRVMBidder {
 				}
 	        }
 		}
-		super.bidderTypeSpecificDemandQueryMIPAdjustments(mip);
 	}
 
     @Override

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidder.java
@@ -23,8 +23,6 @@ import java.util.*;
  *
  */
 public final class MRVMLocalBidder extends MRVMBidder {
-	
-	private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
 
 	private static final long serialVersionUID = -7654713373213024311L;
     /**
@@ -37,6 +35,7 @@ public final class MRVMLocalBidder extends MRVMBidder {
      * Stores the ids of all regions for which this bidder is interested
      */
     final Set<Integer> regionsOfInterest;
+    private final boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
     MRVMLocalBidder(long id, long populationId, MRVMWorld world, MRVMLocalBidderSetup setup,
                     UniformDistributionRNG rng) {
@@ -50,6 +49,7 @@ public final class MRVMLocalBidder extends MRVMBidder {
             regionsOfInterestIds.add(region.getId());
         }
         this.regionsOfInterest = Collections.unmodifiableSet(regionsOfInterestIds);
+        this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = setup.isAllowAssigningLicensesWithZeroBasevalueInDemandQuery();
         store();
     }
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidderSetup.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMLocalBidderSetup.java
@@ -6,6 +6,8 @@
 package org.spectrumauctions.sats.core.model.mrvm;
 
 import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.Setter;
 import org.spectrumauctions.sats.core.util.random.DoubleInterval;
 import org.spectrumauctions.sats.core.util.random.IntegerInterval;
 import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
@@ -20,11 +22,14 @@ public class MRVMLocalBidderSetup extends MRVMBidderSetup {
 
     private final IntegerInterval numberOfRegionsInterval;
     private final List<String> regionNotes;
+    @Getter
+    private final boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
     protected MRVMLocalBidderSetup(Builder builder) {
         super(builder);
         this.numberOfRegionsInterval = builder.numberOfRegionsInterval;
         this.regionNotes = builder.regionNotes;
+        this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = builder.allowAssigningLicensesWithZeroBasevalueInDemandQuery;
     }
 
 
@@ -71,6 +76,8 @@ public class MRVMLocalBidderSetup extends MRVMBidderSetup {
 
         private IntegerInterval numberOfRegionsInterval;
         private List<String> regionNotes;
+        @Setter
+        private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
         public Builder() {
             super("Multi Region Model Local Bidder",
@@ -78,6 +85,7 @@ public class MRVMLocalBidderSetup extends MRVMBidderSetup {
                     new DoubleInterval(60, 100),
                     new DoubleInterval(0.05, 0.12));
             this.numberOfRegionsInterval = new IntegerInterval(3, 7);
+            this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
         }
 
         /**

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMNationalBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMNationalBidder.java
@@ -12,6 +12,7 @@ import org.spectrumauctions.sats.core.model.UnsupportedBiddingLanguageException;
 import org.spectrumauctions.sats.core.util.BigDecimalUtils;
 import org.spectrumauctions.sats.core.util.random.RNGSupplier;
 import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
+import org.spectrumauctions.sats.opt.model.mrvm.MRVM_MIP;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -151,6 +152,11 @@ public final class MRVMNationalBidder extends MRVMBidder {
         }
         return true;
     }
+
+	@Override
+	protected void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip) {
+		// Do nothing
+	}
 
 
 }

--- a/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMRegionalBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/mrvm/MRVMRegionalBidder.java
@@ -12,6 +12,7 @@ import org.spectrumauctions.sats.core.model.World;
 import org.spectrumauctions.sats.core.util.BigDecimalUtils;
 import org.spectrumauctions.sats.core.util.random.RNGSupplier;
 import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
+import org.spectrumauctions.sats.opt.model.mrvm.MRVM_MIP;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -145,6 +146,11 @@ public final class MRVMRegionalBidder extends MRVMBidder {
             return false;
         return true;
     }
+
+	@Override
+	protected void bidderTypeSpecificDemandQueryMIPAdjustments(MRVM_MIP mip) {
+		// Do nothing
+	}
 
 
 }

--- a/src/main/java/org/spectrumauctions/sats/opt/model/gsvm/GSVMStandardMIP.java
+++ b/src/main/java/org/spectrumauctions/sats/opt/model/gsvm/GSVMStandardMIP.java
@@ -34,7 +34,7 @@ public class GSVMStandardMIP extends ModelMIP {
 	private GSVMWorld world;
 
 	private boolean allowAssigningLicensesWithZeroBasevalue;
-	private boolean allowMoreThan4LicencesForRegionalBidders = false;
+	private boolean ignoreActivityLimits = false;
 
 	public GSVMStandardMIP(List<GSVMBidder> population) {
 		this(population.iterator().next().getWorld(), population);
@@ -42,7 +42,7 @@ public class GSVMStandardMIP extends ModelMIP {
 
 	public GSVMStandardMIP(GSVMWorld world, List<GSVMBidder> population) {
 		this.allowAssigningLicensesWithZeroBasevalue = world.isLegacyGSVM();
-		this.allowMoreThan4LicencesForRegionalBidders = world.isLegacyGSVM();
+		this.ignoreActivityLimits = world.isLegacyGSVM();
 		this.population = population;
 		this.world = world;
 		tauHatMap = new HashMap<>();
@@ -168,7 +168,7 @@ public class GSVMStandardMIP extends ModelMIP {
 		}
 		
 		// build regional bidder restrictions
-		if(!allowMoreThan4LicencesForRegionalBidders) {
+		if(!ignoreActivityLimits) {
 			for(GSVMBidder bidder : this.population) {
 				Constraint regionalLimit = new Constraint(CompareType.LEQ,bidder.getActivityLimit());
 				for(GSVMLicense license : world.getLicenses()) {

--- a/src/test/java/org/spectrumauctions/sats/core/model/gsvm/GSVMBidderTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/gsvm/GSVMBidderTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 public class GSVMBidderTest {
 
     private static Bundle completeBundle;
-
+ 
     @BeforeClass
     public static void setUpBeforeClass() {
         GlobalSynergyValueModel model = new GlobalSynergyValueModel();


### PR DESCRIPTION
Demand queries should be restricted to return no bundles that contain items with zero marginal value. 

In GSVM (not legacy) and LSVM these are items with zero base value (In GSVM this is already implemented like this).

I think only the local bidder is affected in MRVM. But I do not know this value model that well so it would be nice if you could double check.

Again test are missing. Sorry. I will add them when I find time.