### PR TITLE
Lsvm v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,13 +238,13 @@
         <dependency>
             <groupId>edu.harvard.eecs</groupId>
             <artifactId>jopt</artifactId>
-            <version>1.3.4</version>
+            <version>1.3.5</version>
         </dependency>
 
         <dependency>
             <groupId>cplex</groupId>
             <artifactId>cplex</artifactId>
-            <version>12.9</version>
+            <version>12.10</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -132,7 +132,25 @@ public final class LSVMBidder extends SATSBidder {
     /**
      * This factor is used to calculate the bonus for having adjacent items.
      * <p>
-     * Note: To our knowledge, Scheffel et al. (2010) do not specify the behavior in case a license is added which the
+     * Note: The current interpretation of Scheffel et al. (2010) is such that a bidder has no positive marginal value
+     * for any licenses he is not interested in. (I.e. adding or removing such a license from a bundle does not change
+     * the value of the bundle). There are mainly two arguments for this interpretation:
+     * 1.  Scheffel et al. (2010) states that the bidding space of the regional bidder consists of 63 - 2047 packages (bundles).
+     *     As a regional bidder is interested in 6 to 11 licenses this makes clear that the bidding space of a regional bidder
+     *     does not include any licences he is not interested in
+     * 2.  This interpretation follows the implementation of GSVM where items of no interest have no influence on the bundle
+     *     values.
+     *     
+     * The former interpretation is stated as Note II. It still applies to the legacy version of LSVM. In addition to this 
+     * note you may notice that licenses where a bidder has no interest in do not only affect the computation of maximally 
+     * connected subsets of licenses, but also increases the synergies in the legacy version. I.e. assume a bundle of 3 
+     * licenses DEJ. The bidder is only interested in licenses E and J. (see table 1 in Scheffel et al. (2010)). In the 
+     * current version no synergies will be applied to this package. The legacy version will apply synergies for 3 licences.
+     * Note II could also be interpreted towards that only synergies for 2 licenses are applied and the license of no interest
+     * (D) only is used to compute maximally connected subpackages. Note that this last interpretation is not implemented
+     * in any version of LSVM in sats.
+     * 
+     * Note II: To our knowledge, Scheffel et al. (2010) do not specify the behavior in case a license is added which the
      * bidder does not have any interest in. This one license could connect two subsets of items which the
      * bidder is interested in, creating one larger subset, thus increasing the bonus for adjacent items.
      * A possible extension of the model is to adjust the bonus accordingly in this situation.

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -141,14 +141,13 @@ public final class LSVMBidder extends SATSBidder {
      * 2.  This interpretation follows the implementation of GSVM where items of no interest have no influence on the bundle
      *     values.
      *     
-     * The former interpretation is stated as Note II. It still applies to the legacy version of LSVM. In addition to this 
-     * note you may notice that licenses where a bidder has no interest in do not only affect the computation of maximally 
-     * connected subsets of licenses, but also increases the synergies in the legacy version. I.e. assume a bundle of 3 
-     * licenses DEJ. The bidder is only interested in licenses E and J. (see table 1 in Scheffel et al. (2010)). In the 
-     * current version no synergies will be applied to this package. The legacy version will apply synergies for 3 licences.
-     * Note II could also be interpreted towards that only synergies for 2 licenses are applied and the license of no interest
-     * (D) only is used to compute maximally connected subpackages. Note that this last interpretation is not implemented
-     * in any version of LSVM in sats.
+     * The interpretation which was used to implement the legacy version of LVSM is stated as Note II. In addition to this note 
+     * you may notice that licenses where a bidder has no interest in, do not only affect the computation of maximally connected 
+     * subsets of licenses, but also increases the synergies in the legacy version. I.e. assume a bundle of 3 licenses DEJ. The 
+     * bidder is only interested in licenses E and J. (see table 1 in Scheffel et al. (2010)). In the current version no synergies 
+     * will be applied to this package. The legacy version will apply synergies for 3 licenses. Note II could also be interpreted 
+     * towards that only synergies for 2 licenses are applied and the license of no interest (D) is only used to compute maximally 
+     * connected subpackages. This last interpretation is not implemented in any version of LSVM in sats.
      * 
      * Note II: To our knowledge, Scheffel et al. (2010) do not specify the behavior in case a license is added which the
      * bidder does not have any interest in. This one license could connect two subsets of items which the

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidder.java
@@ -63,7 +63,11 @@ public final class LSVMBidder extends SATSBidder {
     @Override
     public BigDecimal calculateValue(Bundle bundle) {
         double value = 0;
-        Set<LSVMLicense> licences = bundle.getBundleEntries().stream().map(be -> (LSVMLicense) be.getGood()).collect(Collectors.toSet());
+        Set<LSVMLicense> licences;
+        if(world.isLegacyLSVM())
+        	licences = bundle.getBundleEntries().stream().map(be -> (LSVMLicense) be.getGood()).collect(Collectors.toSet());
+        else 
+        	licences = bundle.getBundleEntries().stream().map(be -> (LSVMLicense) be.getGood()).filter(l -> this.getProximity().contains(l)).collect(Collectors.toSet());
         Set<Set<LSVMLicense>> subpackages = world.getGrid().getMaximallyConnectedSubpackages(licences);
         for (Set<LSVMLicense> subset : subpackages) {
             double factor = calculateFactor(subset.size());

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidderSetup.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMBidderSetup.java
@@ -1,7 +1,5 @@
 package org.spectrumauctions.sats.core.model.lsvm;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.spectrumauctions.sats.core.model.BidderSetup;
 import org.spectrumauctions.sats.core.util.PreconditionUtils;
 import org.spectrumauctions.sats.core.util.random.DoubleInterval;
@@ -21,8 +19,6 @@ public class LSVMBidderSetup extends BidderSetup {
     private final int proximitySize;
     private final int a;
     private final int b;
-    @Getter
-    private final boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
     private LSVMBidderSetup(Builder builder) {
         super(builder);
@@ -30,7 +26,6 @@ public class LSVMBidderSetup extends BidderSetup {
         this.proximitySize = builder.proximitySize;
         this.a = builder.a;
         this.b = builder.b;
-        this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = builder.allowAssigningLicensesWithZeroBasevalueInDemandQuery;
     }
 
     LSVMLicense drawFavorite(RNGSupplier rngSupplier, LSVMWorld world) {
@@ -71,8 +66,6 @@ public class LSVMBidderSetup extends BidderSetup {
         private int proximitySize;
         private int a;
         private int b;
-        @Setter
-        private boolean allowAssigningLicensesWithZeroBasevalueInDemandQuery;
 
         private Builder(String setupName, int numberOfBidders, DoubleInterval valueInterval, int proximitySize, int a, int b) {
             super(setupName, numberOfBidders);
@@ -80,7 +73,6 @@ public class LSVMBidderSetup extends BidderSetup {
             this.proximitySize = proximitySize;
             this.a = a;
             this.b = b;
-            this.allowAssigningLicensesWithZeroBasevalueInDemandQuery = false;
         }
 
         public void setValueInterval(DoubleInterval newInterval) {

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMWorld.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMWorld.java
@@ -1,6 +1,9 @@
 package org.spectrumauctions.sats.core.model.lsvm;
 
 import com.google.common.collect.ImmutableList;
+
+import lombok.Getter;
+
 import org.spectrumauctions.sats.core.model.World;
 import org.spectrumauctions.sats.core.util.random.RNGSupplier;
 import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
@@ -17,11 +20,21 @@ public final class LSVMWorld extends World {
     private static final long serialVersionUID = 1737956689715986936L;
     private static final String MODEL_NAME = "Local Synergy Value Model";
     private final LSVMGrid grid;
+    
+    /**
+     *  In earlier versions of SATS (<0.7.0), the original model was interpreted differently than it is today.
+     *  Back then, when asking a bidder what her value is for bundle X, the synergy factor increased with any good in X.
+     *  Now, the synergy factor only increases with goods which the bidder has a positive value for.
+     *  This flag can be set to true in order to reproduce results of the old SATS versions.
+     */
+    @Getter
+    private final boolean isLegacyLSVM;
 
     public LSVMWorld(LSVMWorldSetup worldSetup, RNGSupplier rngSupplier) {
         super(MODEL_NAME);
         UniformDistributionRNG uniformDistributionRNG = rngSupplier.getUniformDistributionRNG();
         this.grid = new LSVMGrid(this, worldSetup, uniformDistributionRNG);
+        this.isLegacyLSVM = worldSetup.isLegacyLSVM();
         store();
     }
 

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMWorldSetup.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LSVMWorldSetup.java
@@ -4,6 +4,9 @@ import org.spectrumauctions.sats.core.util.PreconditionUtils;
 import org.spectrumauctions.sats.core.util.random.IntegerInterval;
 import org.spectrumauctions.sats.core.util.random.UniformDistributionRNG;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @author Fabio Isler
  */
@@ -11,11 +14,14 @@ public class LSVMWorldSetup {
 
     private final IntegerInterval numberOfRowsInterval;
     private final IntegerInterval numberOfColumnsInterval;
+    @Getter
+    private final boolean isLegacyLSVM;
 
     private LSVMWorldSetup(LSVMWorldSetupBuilder builder) {
         super();
         this.numberOfRowsInterval = builder.numberOfRowsInterval;
         this.numberOfColumnsInterval = builder.numberOfColumnsInterval;
+        this.isLegacyLSVM = builder.isLegacyLSVM();
     }
 
     Integer drawRowNumber(UniformDistributionRNG rng) {
@@ -33,6 +39,9 @@ public class LSVMWorldSetup {
 
         private IntegerInterval numberOfRowsInterval;
         private IntegerInterval numberOfColumnsInterval;
+        
+        @Setter @Getter
+        private boolean isLegacyLSVM = false;
 
         public LSVMWorldSetupBuilder() {
             super();

--- a/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LocalSynergyValueModel.java
+++ b/src/main/java/org/spectrumauctions/sats/core/model/lsvm/LocalSynergyValueModel.java
@@ -41,4 +41,8 @@ public class LocalSynergyValueModel extends DefaultModel<LSVMWorld, LSVMBidder> 
     public void setNumberOfRegionalBidders(int numberOfBidders) {
         regionalBidderBuilder.setNumberOfBidders(numberOfBidders);
     }
+    
+    public void setLegacyLSVM(boolean legacyLSVM) {
+        worldSetupBuilder.setLegacyLSVM(legacyLSVM);
+    }
 }

--- a/src/main/java/org/spectrumauctions/sats/opt/model/lsvm/LSVMStandardMIP.java
+++ b/src/main/java/org/spectrumauctions/sats/opt/model/lsvm/LSVMStandardMIP.java
@@ -72,6 +72,9 @@ public class LSVMStandardMIP extends ModelMIP {
 		buildNeighbourConstraints();
 		buildEdgeConstraints();
 		buildTauConstraints();
+		if(!this.world.isLegacyLSVM()) {
+			buildLicenceRestrictions();
+		}
 	}
 
 	@Override
@@ -239,6 +242,20 @@ public class LSVMStandardMIP extends ModelMIP {
                 getMIP().add(constraint);
             }
         }
+	}
+	
+	private void buildLicenceRestrictions() {
+		for (LSVMBidder bidder : population) {
+			for (LSVMLicense license : world.getLicenses()) {
+	        	Map<Integer, Variable> xVariables = this.getXVariables(bidder, license);
+	        	for (Variable xVariable : xVariables.values()) {
+	        		if(!bidder.getProximity().contains(license)) {
+	        			xVariable.setUpperBound(0);
+	        		}
+	        	}
+
+	        }
+		}
 	}
 
 	private void initBaseValues() {

--- a/src/test/java/org/spectrumauctions/sats/core/model/mrvm/MRVMWorldTest.java
+++ b/src/test/java/org/spectrumauctions/sats/core/model/mrvm/MRVMWorldTest.java
@@ -29,10 +29,10 @@ public class MRVMWorldTest {
         world = new MRVMWorld(MRMSimpleWorldGen.getSimpleWorldBuilder(), new JavaUtilRNGSupplier(983742L));
     }
 
-    @Test
     /**
-     * Checks if the complete bundle is split correcly into regional bundles
+     * Checks if the complete bundle is split correctly into regional bundles
      */
+    @Test
     public void selectAllLicensesOfRegionOnCompleteBundle() {
         Map<MRVMRegionsMap.Region, Set<MRVMLicense>> regionalBundles = MRVMWorld.getLicensesPerRegion(Sets.newHashSet(world.getLicenses()));
         int expectedNumberOfLicenses = 0;

--- a/src/test/java/org/spectrumauctions/sats/opt/model/lsvm/LSVMStandardMIPTest.java
+++ b/src/test/java/org/spectrumauctions/sats/opt/model/lsvm/LSVMStandardMIPTest.java
@@ -32,28 +32,30 @@ public class LSVMStandardMIPTest {
 	}
 
 	@Test
-	@Ignore // FIXME: Currently, value is 542.9613847418564 (instead of 550.547333429). Most probably world changed for same seed.
-	public void testDefaultSetupEasySeed() {
+	// FIXME: Currently, value is 542.9613847418564 (instead of 550.547333429). Most probably world changed for same seed.
+	public void testLegacyDefaultSetupEasySeed() {
 		// reference runtime approx 2 seconds
-		testDefaultSetup(1498246131808L);
+		testLegacyDefaultSetup(1498246131808L);
 	}
 
 	@Test
-	@Ignore // FIXME: Currently, value is 506.579764315678 (instead of 502.943796697). Most probably world changed for same seed.
-	public void testDefaultSetupMediumSeed() {
+	// FIXME: Currently, value is 506.579764315678 (instead of 502.943796697). Most probably world changed for same seed.
+	public void testLegacyDefaultSetupMediumSeed() {
 		// reference runtime approx 1 minute
-		testDefaultSetup(1498247338147L);
+		testLegacyDefaultSetup(1498247338147L);
 	}
 
-	// @Test -> Uncomment to test the hard seed
-	public void testDefaultSetupHardSeed() {
+	@Test
+	@Ignore // -> Remove to test the hard seed
+	public void testLegacyDefaultSetupHardSeed() {
 		// hardest known seed -> reference runtime approx 15 minutes
-		testDefaultSetup(1498249317254L);
+		testLegacyDefaultSetup(1498249317254L);
 	}
 
 	@Test
 	public void testEfficientAllocationCustomSetup() {
 		LSVMWorldSetup.LSVMWorldSetupBuilder worldSetupBuilder = new LSVMWorldSetup.LSVMWorldSetupBuilder();
+		worldSetupBuilder.setLegacyLSVM(true);
 		worldSetupBuilder.setNumberOfColumnsInterval(new IntegerInterval(3));
 		worldSetupBuilder.setNumberOfRowsInterval(new IntegerInterval(2));
 		LSVMWorldSetup setup = worldSetupBuilder.build();
@@ -66,8 +68,9 @@ public class LSVMStandardMIPTest {
 		testTotalValue(population, allocation);
 	}
 
-	private void testDefaultSetup(Long seed) {
+	private void testLegacyDefaultSetup(Long seed) {
 		LocalSynergyValueModel model = new LocalSynergyValueModel();
+		model.setLegacyLSVM(true);
 		LSVMWorld world = model.createWorld(seed);
 		List<LSVMBidder> population = model.createPopulation(world, seed);
 


### PR DESCRIPTION
I discovered that we have the same issue with LSVM as we had in GSVM. The synergy continues also for items with zero base value which was for sure not the intention of the original authors of LSVM. Therefore we decided to change the model to the original one.

I implemented the same legacy switch as for GSVM and implemented the restriction in the same way as in GSVM (i.e. there is no more free disposal in the MIP). 

Of course it would be nice to have some tests, but I had not yet time to write some.